### PR TITLE
Add aggregateRating to output.

### DIFF
--- a/class-be-product-review.php
+++ b/class-be-product-review.php
@@ -55,6 +55,11 @@ class BE_Product_Review extends \WPSEO_Schema_Article implements \WPSEO_Graph_Pi
 						'@id'  => $this->context->canonical . WPSEO_Schema_IDs::PRIMARY_IMAGE_HASH,
 					),
 					'name'     => wp_strip_all_tags( $this->get_review_meta( 'name', get_the_title() ) ),
+					'aggregateRating' => array(
+						'@type' => 'AggregateRating',
+						'ratingValue'  => esc_attr( $this->get_review_meta( 'rating', 1 ) ),
+						'reviewCount' => 1
+					)
 			),
 			'reviewRating'     => array(
 				'@type'        => 'Rating',


### PR DESCRIPTION
This patch fixes a problem whereby Google Structured Data Testing Tool complains
"Either “offers”, “review”, or “aggregateRating” should be specified".
I figure it's technically correct that, for a product in a review post,
the aggregate rating would be whatever the rating metadata says, and the
number of applicable reviews is 1 - this seemed like the most
appropriate way of satisfying the checker.